### PR TITLE
Added new logic for Algae and Coral Subsystems in transitionToStateCommand

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -205,7 +205,7 @@ public class RobotContainer {
                   Math.abs(CoralSubsystem.getCoralRotationPosition() - CoralSubsystem.kStowedPosition) < 0.01
         );
     
-        // Step 2: Adjust Algae to Safe Position (ReefPickup) if entering/leaving kShootingPosition or moving from kStowedPosition
+        // Step 2: Adjust Algae to Safe Position (kSafePosition) if entering/leaving kShootingPosition or moving from kStowedPosition
         Command adjustAlgaeToSafe = Commands.either(
             Commands.none(),
             Commands.sequence(
@@ -219,9 +219,9 @@ public class RobotContainer {
                     () -> Math.abs(AlgaeSubsystem.getAlgaeRotationPosition() - AlgaeSubsystem.kStowedPosition) < 0.01 && 
                           config.algaeTarget != AlgaeSetpoint.kStowedPosition
                 ),
-                Commands.runOnce(() -> System.out.println("Step: Algae to Safe (ReefPickup)")),
-                AlgaeSubsystem.setSetpointCommand(AlgaeSetpoint.kReefPickupPosition),
-                Commands.waitUntil(() -> Math.abs(AlgaeSubsystem.getAlgaeRotationPosition() - AlgaeSubsystem.kReefPickupPosition) < 0.01).withTimeout(10.0)
+                Commands.runOnce(() -> System.out.println("Step: Algae to Safe (SafePosition)")),
+                AlgaeSubsystem.setSetpointCommand(AlgaeSetpoint.kSafePosition), // Changed from kReefPickupPosition
+                Commands.waitUntil(() -> Math.abs(AlgaeSubsystem.getAlgaeRotationPosition() - AlgaeSubsystem.kSafePosition) < 0.01).withTimeout(10.0)
             ),
             () -> {
                 boolean elevatorMoving = Math.abs(ElevatorSubsystem.getElevatorPosition() - getSetpointValue(config.elevatorTarget)) > 1;
@@ -255,8 +255,8 @@ public class RobotContainer {
                         Commands.runOnce(() -> System.out.println("Step: Elevator to Stowed for Algae Stow")),
                         ElevatorSubsystem.setSetpointCommand(ElevatorSetpoint.kStowedPosition),
                         Commands.waitUntil(() -> Math.abs(ElevatorSubsystem.getElevatorPosition() - ElevatorSubsystem.kStowedPosition) < 1).withTimeout(10.0),
-                        AlgaeSubsystem.setSetpointCommand(config.algaeTarget == AlgaeSetpoint.kStowedPosition && AlgaeSubsystem.getLoadedLocked() ? AlgaeSetpoint.kReefPickupPosition : config.algaeTarget),
-                        Commands.waitUntil(() -> Math.abs(AlgaeSubsystem.getAlgaeRotationPosition() - getSetpointValue(config.algaeTarget == AlgaeSetpoint.kStowedPosition && AlgaeSubsystem.getLoadedLocked() ? AlgaeSetpoint.kReefPickupPosition : config.algaeTarget)) < 0.01).withTimeout(10.0)
+                        AlgaeSubsystem.setSetpointCommand(config.algaeTarget == AlgaeSetpoint.kStowedPosition && AlgaeSubsystem.getLoadedLocked() ? AlgaeSetpoint.kSafePosition : config.algaeTarget), // Changed from kReefPickupPosition
+                        Commands.waitUntil(() -> Math.abs(AlgaeSubsystem.getAlgaeRotationPosition() - getSetpointValue(config.algaeTarget == AlgaeSetpoint.kStowedPosition && AlgaeSubsystem.getLoadedLocked() ? AlgaeSetpoint.kSafePosition : config.algaeTarget)) < 0.01).withTimeout(10.0)
                     ),
                     Commands.either(
                         Commands.sequence(
@@ -265,13 +265,13 @@ public class RobotContainer {
                             Commands.waitUntil(() -> Math.abs(ElevatorSubsystem.getElevatorPosition() - ElevatorSubsystem.kAlgaeShootingPosition) < 1).withTimeout(10.0),
                             AlgaeSubsystem.setSetpointCommand(AlgaeSetpoint.kShootingPosition)
                         ),
-                        AlgaeSubsystem.setSetpointCommand(config.algaeTarget == AlgaeSetpoint.kStowedPosition && AlgaeSubsystem.getLoadedLocked() ? AlgaeSetpoint.kReefPickupPosition : config.algaeTarget),
+                        AlgaeSubsystem.setSetpointCommand(config.algaeTarget == AlgaeSetpoint.kStowedPosition && AlgaeSubsystem.getLoadedLocked() ? AlgaeSetpoint.kSafePosition : config.algaeTarget), // Changed from kReefPickupPosition
                         () -> config.algaeTarget == AlgaeSetpoint.kShootingPosition
                     ),
                     () -> config.algaeTarget == AlgaeSetpoint.kStowedPosition && 
                           Math.abs(AlgaeSubsystem.getAlgaeRotationPosition() - AlgaeSubsystem.kStowedPosition) >= 0.01
                 ),
-                Commands.waitUntil(() -> Math.abs(AlgaeSubsystem.getAlgaeRotationPosition() - getSetpointValue(config.algaeTarget == AlgaeSetpoint.kStowedPosition && AlgaeSubsystem.getLoadedLocked() ? AlgaeSetpoint.kReefPickupPosition : config.algaeTarget)) < 0.01).withTimeout(10.0)
+                Commands.waitUntil(() -> Math.abs(AlgaeSubsystem.getAlgaeRotationPosition() - getSetpointValue(config.algaeTarget == AlgaeSetpoint.kStowedPosition && AlgaeSubsystem.getLoadedLocked() ? AlgaeSetpoint.kSafePosition : config.algaeTarget)) < 0.01).withTimeout(10.0)
             ),
             () -> Math.abs(AlgaeSubsystem.getAlgaeRotationPosition() - getSetpointValue(config.algaeTarget)) < 0.01
         );
@@ -331,6 +331,7 @@ public class RobotContainer {
                 case kProcessorPosition -> AlgaeSubsystem.kProcessorPosition;
                 case kReefPickupPosition -> AlgaeSubsystem.kReefPickupPosition;
                 case kShootingPosition -> AlgaeSubsystem.kShootingPosition;
+                case kSafePosition -> AlgaeSubsystem.kSafePosition;
             };
         } else if (setpoint instanceof ElevatorSetpoint) {
             return switch ((ElevatorSetpoint) setpoint) {

--- a/src/main/java/frc/robot/RobotStateConfig.java
+++ b/src/main/java/frc/robot/RobotStateConfig.java
@@ -67,13 +67,13 @@ public class RobotStateConfig {
 
     public static final RobotStateConfig CORAL_SHOOTING_LEVEL_2 = new RobotStateConfig(
         CoralSetpoint.kShootingPosition,
-        AlgaeSetpoint.kReefPickupPosition,
+        AlgaeSetpoint.kStowedPosition,
         ElevatorSetpoint.kLevel2
     );
 
     public static final RobotStateConfig CORAL_SHOOTING_LEVEL_3 = new RobotStateConfig(
         CoralSetpoint.kShootingPosition,
-        AlgaeSetpoint.kReefPickupPosition,
+        AlgaeSetpoint.kStowedPosition,
         ElevatorSetpoint.kLevel3
     );
 

--- a/src/main/java/frc/robot/subsystems/AlgaeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/AlgaeSubsystem.java
@@ -25,7 +25,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 public class AlgaeSubsystem extends SubsystemBase {
   /** Creates a new IntakeSubsystem. */
   public SparkFlex algaeIntakeMotor = new SparkFlex(13, MotorType.kBrushless);
-  SparkFlex algaeIntakeRotationMotor = new SparkFlex(14, MotorType.kBrushless);
+  public SparkFlex algaeIntakeRotationMotor = new SparkFlex(14, MotorType.kBrushless);
 
   SparkFlexConfig algaeIntakeMotorConfig = new SparkFlexConfig();
   SparkFlexConfig algaeRotationMotorConfig = new SparkFlexConfig();
@@ -34,8 +34,8 @@ public class AlgaeSubsystem extends SubsystemBase {
   RelativeEncoder algaeRotationEncoder = algaeIntakeRotationMotor.getExternalEncoder();
 
   public static final double kStowedPosition = 0;
-  public static final double kGroundPickupPosition = .8;
-  public static final double kProcessorPosition = .6;
+  public static final double kGroundPickupPosition = .5;
+  public static final double kProcessorPosition = .4;
   public static final double kReefPickupPosition = .5;
   public static final double kShootingPosition = .2;
 
@@ -132,10 +132,15 @@ public class AlgaeSubsystem extends SubsystemBase {
       algaeRotationCurrentTarget, ControlType.kMAXMotionPositionControl);
   }
 
+  public double getAlgaeMotorOutput() {
+    // Updated to reflect actual control output
+    return algaeIntakeRotationMotor.getAppliedOutput(); // Use duty cycle for PositionVoltage
+  }
+
   @Override
   public void periodic() {
     // This method will be called once per scheduler run
-    moveToSetpoint();
+    //moveToSetpoint();
 
     // Debug current command state
     Command currentCmd = this.getCurrentCommand();
@@ -178,56 +183,41 @@ public class AlgaeSubsystem extends SubsystemBase {
     return Commands.runOnce(() -> algaeIntakeMotor.stopMotor()).withName("StopAlgaeIntake");
   }
 
-  public Command setSetpointCommand(AlgaeSetpoint algaesetpoint, boolean continuous) {
-    if (continuous) {
-        return Commands.run(() -> {
-            switch (algaesetpoint) {
-                case kStowedPosition:
-                    algaeRotationCurrentTarget = kStowedPosition;
-                    break;
-                case kGroundPickupPosition:
-                    algaeRotationCurrentTarget = kGroundPickupPosition;
-                    break;
-                case kProcessorPosition:
-                    algaeRotationCurrentTarget = kProcessorPosition;
-                    break;
-                case kReefPickupPosition:
-                    algaeRotationCurrentTarget = kReefPickupPosition;
-                    break;
-                case kShootingPosition:
-                    algaeRotationCurrentTarget = kShootingPosition;
-                    break;
-            }
-            moveToSetpoint();
-        }, this);
-    } else {
-        return runOnce(() -> {
-            switch (algaesetpoint) {
-                case kStowedPosition:
-                    algaeRotationCurrentTarget = kStowedPosition;
-                    break;
-                case kGroundPickupPosition:
-                    algaeRotationCurrentTarget = kGroundPickupPosition;
-                    break;
-                case kProcessorPosition:
-                    algaeRotationCurrentTarget = kProcessorPosition;
-                    break;
-                case kReefPickupPosition:
-                    algaeRotationCurrentTarget = kReefPickupPosition;
-                    break;
-                case kShootingPosition:
-                    algaeRotationCurrentTarget = kShootingPosition;
-                    break;
-            }
-            moveToSetpoint();
-        });
-    }
+  public Command setSetpointCommand(AlgaeSetpoint algaesetpoint) {
+    return Commands.run(() -> {
+        double target;
+        boolean loaded = getLoadedLocked(); // Use locked state for consistency
+        switch (algaesetpoint) {
+            case kStowedPosition:
+                target = loaded ? kReefPickupPosition : kStowedPosition;
+                break;
+            case kGroundPickupPosition:
+                target = kGroundPickupPosition;
+                break;
+            case kProcessorPosition:
+                target = kProcessorPosition;
+                break;
+            case kReefPickupPosition:
+                target = kReefPickupPosition;
+                break;
+            case kShootingPosition:
+                target = kShootingPosition;
+                break;
+            default:
+                target = kStowedPosition;
+        }
+        algaeRotationCurrentTarget = target;
+        moveToSetpoint();
+        System.out.println("AlgaeSubsystem: Setting target to " + target + " (Locked Loaded: " + loaded + ", Live Loaded: " + isAlgaeIntakeLoaded() + ")");
+    }, this).until(() -> Math.abs(getAlgaeRotationPosition() - algaeRotationCurrentTarget) < 0.01)
+    .withTimeout(15.0) // Increased from 10.0
+    .withName("AlgaeTo" + algaesetpoint);
 }
 
 // Overload for default (non-continuous)
-public Command setSetpointCommand(AlgaeSetpoint algaesetpoint) {
-  return setSetpointCommand(algaesetpoint, false);
-}
+// public Command setSetpointCommand(AlgaeSetpoint algaesetpoint) {
+//   return setSetpointCommand(algaesetpoint, false);
+// }
 
   public Map<String, Command> getNamedCommands() {
     return Map.of(

--- a/src/main/java/frc/robot/subsystems/AlgaeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/AlgaeSubsystem.java
@@ -38,6 +38,7 @@ public class AlgaeSubsystem extends SubsystemBase {
   public static final double kProcessorPosition = .4;
   public static final double kReefPickupPosition = .5;
   public static final double kShootingPosition = .2;
+  public static final double kSafePosition = .45;
 
   /** Subsystem-wide setpoints */
   public enum AlgaeSetpoint {
@@ -45,7 +46,8 @@ public class AlgaeSubsystem extends SubsystemBase {
     kGroundPickupPosition,
     kProcessorPosition,
     kReefPickupPosition,
-    kShootingPosition
+    kShootingPosition,
+    kSafePosition
   }
 
   private double algaeRotationCurrentTarget = kStowedPosition;
@@ -189,7 +191,7 @@ public class AlgaeSubsystem extends SubsystemBase {
         boolean loaded = getLoadedLocked(); // Use locked state for consistency
         switch (algaesetpoint) {
             case kStowedPosition:
-                target = loaded ? kReefPickupPosition : kStowedPosition;
+                target = loaded ? kSafePosition : kStowedPosition;
                 break;
             case kGroundPickupPosition:
                 target = kGroundPickupPosition;
@@ -202,6 +204,9 @@ public class AlgaeSubsystem extends SubsystemBase {
                 break;
             case kShootingPosition:
                 target = kShootingPosition;
+                break;
+            case kSafePosition:
+                target = kSafePosition;
                 break;
             default:
                 target = kStowedPosition;
@@ -236,7 +241,9 @@ public class AlgaeSubsystem extends SubsystemBase {
       "Set_Algae_Setpoint_Reef_Pickup",
       setSetpointCommand(AlgaeSetpoint.kReefPickupPosition),
       "Set_Algae_Setpoint_Shooting",
-      setSetpointCommand(AlgaeSetpoint.kShootingPosition)
+      setSetpointCommand(AlgaeSetpoint.kShootingPosition),
+      "Set_Algae_Setpoint_Safe", 
+      setSetpointCommand(AlgaeSetpoint.kSafePosition)
     );
   }
 }

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -35,7 +35,7 @@ public class ElevatorSubsystem extends SubsystemBase {
 
   public static final int kStowedPosition = 0;
   public static final int kGroundPosition = 7;
-  public static final int kFeederStation = 0;
+  public static final int kFeederStation = 5;
   public static final int kLevel1 = 0;
   public static final int kLevel2 = 10;
   public static final int kLevel3 = 15;


### PR DESCRIPTION

This pull request includes significant changes to the `transitionToStateCommand` method in the `RobotContainer.java` file. The changes aim to improve the sequence of state transitions for the robot's subsystems, ensuring that rules are enforced and the system operates safely.

Key changes include:

### Improvements to State Transition Sequence:

* Updated the sequence for transitioning the robot's state, including new steps for moving the coral, algae, and elevator subsystems to their target positions. The changes ensure that each subsystem moves in a safe order and adheres to the defined rules.

### Debugging Enhancements:

* Added a `debugStart` command to log the initial positions of the algae, elevator, and coral subsystems, providing better insights during the transition process.

### Safety and Rule Enforcement:

* Introduced new conditions and commands to ensure the algae and coral subsystems move to safe positions before other subsystems transition. This includes moving the algae to a `kSafePosition` instead of `kReefPickupPosition` and adding checks to prevent the coral from moving to the `kStartingPosition` if it is loaded.

### Timeout Adjustments:

* Adjusted the timeout values for various wait commands to ensure that the transitions complete within a reasonable time frame, improving the reliability of the state transitions.